### PR TITLE
feat: orient quads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "twirl"
-version = "0.5.0"
+version = "0.5.1"
 description = "Astrometric plate solving in Python"
 authors = ["Lionel J. Garcia <lionel_garcia@live.fr>"]
 maintainers = [

--- a/twirl/quads.py
+++ b/twirl/quads.py
@@ -46,7 +46,10 @@ def quad_hash(quads):
         y = (rp @ (b - a).T).T + a
         return x, y
 
+    reverse = (np.cross((b - a), (b - c))) >= 0
     u1, u2 = u1u2(a, b)
+    # invert u1 and u2 for reversed quads
+    u1[reverse], u2[reverse] = u2[reverse], u1[reverse]
 
     def proj(p, origin, axe):
         """projection of a point p on a segment from origin to axe"""

--- a/twirl/quads.py
+++ b/twirl/quads.py
@@ -29,7 +29,7 @@ def good_quads(quads, circletol=0.01):
     return np.all(in_circle, axis=1)
 
 
-def quad_hash(quads):
+def quad_hash(quads, oriented=True):
     a, b, c, d = np.rollaxis(quads, 1)
 
     norm = np.linalg.norm(b - a, axis=1)
@@ -46,10 +46,12 @@ def quad_hash(quads):
         y = (rp @ (b - a).T).T + a
         return x, y
 
-    reverse = (np.cross((b - a), (b - c))) >= 0
     u1, u2 = u1u2(a, b)
-    # invert u1 and u2 for reversed quads
-    u1[reverse], u2[reverse] = u2[reverse], u1[reverse]
+
+    if oriented:
+        reverse = (np.cross((b - a), (b - c))) >= 0
+        # invert u1 and u2 for reversed quads
+        u1[reverse], u2[reverse] = u2[reverse], u1[reverse]
 
     def proj(p, origin, axe):
         """projection of a point p on a segment from origin to axe"""


### PR DESCRIPTION
Orient quads using BAC angle sign so that u1-u2 basis always have consistent orientation. In Lang2009 this is by including permuted quads.

For reference, here is a place where non-oriented quads limit the match
```python
from scipy.spatial import cKDTree

import numpy as np

radecs = np.array(
    [
        [
            274.73148949,
            274.86490329,
            274.84561483,
            274.85110499,
            274.90849086,
            274.90721201,
            274.75127985,
            274.78820829,
            274.77117239,
            274.79333541,
            274.75682744,
            274.87694318,
            274.76899521,
            274.80959496,
            274.92856186,
        ],
        [
            -68.14639379,
            -68.15990274,
            -68.16806503,
            -68.15018564,
            -68.15770553,
            -68.17102645,
            -68.15448174,
            -68.12906399,
            -68.16645804,
            -68.13535781,
            -68.13438334,
            -68.14672887,
            -68.16049091,
            -68.17644741,
            -68.12362587,
        ],
    ]
).T

pixels = np.array(
    [
        [
            1874.23682135,
            906.47045569,
            744.72233708,
            862.92482627,
            1554.26186158,
            377.22820759,
            31.92397294,
            66.8977319,
            1705.18939397,
            386.0952344,
            1435.64933862,
            1353.8251716,
            1534.62432011,
            425.8644209,
            386.17091984,
        ],
        [
            946.4496088,
            460.92037899,
            647.68930592,
            867.8975847,
            22.10989145,
            699.83604197,
            1521.24951425,
            1924.84590848,
            764.02973769,
            396.82036351,
            525.75953215,
            1201.6207975,
            493.05218508,
            1869.49881979,
            114.5057253,
        ],
    ]
).T

from itertools import combinations
from collections import defaultdict
from twirl.quads import reorder, good_quads, quad_hash
from twirl.match import get_transform_matrix, pad, count_cross_match


def count_macthes(pixels, radecs, oriented=True):

    def hashes(xy, oriented=True):
        assert xy.shape[1] == 2
        quads_idxs = np.array(list(combinations(np.arange(xy.shape[0]), 4)))
        quads = xy[quads_idxs]
        ordered_quads = reorder(quads)
        good_ordered_quads = ordered_quads[good_quads(ordered_quads)]
        h, u = quad_hash(good_ordered_quads, oriented=oriented)
        # we sort hashes from larger AB (see Lang 2008)
        idxs = np.argsort(np.linalg.norm(u[:, 1] - u[:, 0], axis=1))
        return h[idxs[::-1]], good_ordered_quads[idxs[::-1]]

    hashes_pixels, asterism_pixels = hashes(pixels, oriented=oriented)
    hashes_radecs, asterism_radecs = hashes(radecs, oriented=oriented)

    tree_pixels = cKDTree(hashes_pixels)
    tree_radecs = cKDTree(hashes_radecs)
    pairs = []

    ball_query = tree_pixels.query_ball_tree(tree_radecs, r=0.1)
    matches = []

    for i, j in enumerate(ball_query):
        if len(j) > 0:
            pairs += [[i, k] for k in j]

    print("Number of candidate pairs:", len(pairs))
    print("------------------------------")

    for i, j in pairs:
        M = get_transform_matrix(asterism_radecs[j], asterism_pixels[i])
        test = (M @ pad(radecs).T)[0:2].T
        match = count_cross_match(pixels, test, 10)
        matches.append(match)

    match_counts = defaultdict(int)
    for m in matches:
        match_counts[m] += 1

    for k, v in match_counts.items():
        print(f"{v} pair{'s'if v>1 else ''} led to {k} cross_matches")
```
```python
count_macthes(pixels, radecs, oriented=False)
```
```
Number of candidate pairs: 2055
------------------------------
595 pairs led to 1 cross_matches
1134 pairs led to 0 cross_matches
51 pairs led to 4 cross_matches
228 pairs led to 2 cross_matches
46 pairs led to 3 cross_matches
1 pair led to 9 cross_matches
```
Here only one pair out of 2055 led to an accepted transform (9 stars crossed matched).

Orienting the match
```python
count_macthes(pixels, radecs, oriented=True)
```
```
Number of candidate pairs: 3633
------------------------------
1984 pairs led to 0 cross_matches
1096 pairs led to 1 cross_matches
379 pairs led to 2 cross_matches
93 pairs led to 4 cross_matches
72 pairs led to 3 cross_matches
9 pairs led to 9 cross_matches
```
lead to 9 pairs having cross-match and more pairs being formed.

