### PR TITLE
Fix and add test for #41

### DIFF
--- a/tests/test_sparsify.py
+++ b/tests/test_sparsify.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from twirl import sparsify
+
+
+def test_sparsify_does_not_drop_first():
+    # Regression test for issue lgarci/twirl#41
+
+    # Note that these are 0.1 degree from each other
+    input_coords = np.array([[1, 0], [1.1, 0], [1.2, 0]])
+
+    # All coordinate separations are larger than 0.01 deg
+    # so none should get dropped.
+    output_coords = sparsify(input_coords, 0.01)
+
+    # make sure none got dropped based on length
+    assert output_coords.shape == input_coords.shape
+
+    # Make sure the values were not changed
+    assert np.all(output_coords == input_coords)

--- a/twirl/geometry.py
+++ b/twirl/geometry.py
@@ -143,7 +143,9 @@ def sparsify(coords: np.ndarray, radius: float) -> np.ndarray:
         from each other.
     """
     _coords = coords.copy()
-    deleted_coords = np.zeros([], dtype=int)
+    # np.empty instead of np.zeros because the value of np.zeros will be
+    # zero, leading to lgarcia/twirl#41
+    deleted_coords = np.empty([], dtype=int)
     sparse_coords = []
 
     for i, s in enumerate(_coords):


### PR DESCRIPTION
This fixes #41 by using `np.empty` instead of `np.zeros` to initialize the array of dropped indices.