### PR TITLE
Dependency constraint modernisation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ keywords = ["astronomy", "astrometry", "plate-solving"]
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
 astropy = ">=7.2.0,<8"
-astroquery = "^0.4.6"
+astroquery = ">=0.4.6,<1"
 matplotlib = "^3.10.0"
 numpy = "^2.0.0"
 requests = "^2.32.3"
-scikit-image = "^0.25.0"
+scikit-image = ">=0.25.0,<2"
 scipy = "^1.15.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,10 @@ keywords = ["astronomy", "astrometry", "plate-solving"]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
-astropy = ">=5.1.1,<8"
+astropy = ">=7.2.0,<8"
 astroquery = "^0.4.6"
 matplotlib = "^3.10.0"
-numpy = "^1.26.4"
+numpy = "^2.0.0"
 requests = "^2.32.3"
 scikit-image = "^0.25.0"
 scipy = "^1.15.0"

--- a/twirl/quads.py
+++ b/twirl/quads.py
@@ -48,8 +48,11 @@ def quad_hash(quads, oriented=True):
 
     u1, u2 = u1u2(a, b)
 
+    def cross2d(x, y):
+        return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
+
     if oriented:
-        reverse = (np.cross((b - a), (b - c))) >= 0
+        reverse = (cross2d((b - a), (b - c))) >= 0
         # invert u1 and u2 for reversed quads
         u1[reverse], u2[reverse] = u2[reverse], u1[reverse]
 


### PR DESCRIPTION
Different packages, such as `photutils>=3.0.0`, require `numpy>=2`, which is currently incompatible with Twirl. This PR relaxes the version constraints to resolve that conflict.

## Summary

- Bump `numpy` to `>=2.0.0` and `astropy` to `>=7.2.0;
  numpy 2.0 removes deprecated APIs that astropy <7.2 relies on (`np.in1d`)
- Replace `np.cross` on 2-D vectors in `quads.py` with an explicit `cross2d`
  helper, resolving the numpy 2.0 deprecation warning
- Loosen `scikit-image` (`^0.25` → `>=0.25,<2`) and `astroquery`
  (`^0.4.6` → `>=0.4.6,<1`) — Poetry's `^` on `0.x` versions pins a single
  minor series, unnecessarily blocking compatible releases

## Test plan

- [ ] `poetry lock && poetry install`
- [x] `pytest` passes (30/30)